### PR TITLE
Add releases and cert configuration for BAPC and NWERC sites

### DIFF
--- a/apps/_clusters/release/kustomization.yaml
+++ b/apps/_clusters/release/kustomization.yaml
@@ -13,4 +13,7 @@ resources:
   - ../../wiki
   - ../../cod
   - ../../chipcie-website
+  - ../../chipcie-legacy
+  - ../../chipcie-nwerc-2022
+  - ../../chipcie-nwerc-2023
   - ../../archive

--- a/apps/chipcie-legacy/image.yaml
+++ b/apps/chipcie-legacy/image.yaml
@@ -1,0 +1,23 @@
+apiVersion: image.toolkit.fluxcd.io/v1beta1
+kind: ImageRepository
+metadata:
+  name: chipcie-legacy
+  namespace: flux-system
+spec:
+  image: ghcr.io/wisvch/chipcie-legacy
+  interval: 15m0s
+---
+apiVersion: image.toolkit.fluxcd.io/v1beta1
+kind: ImagePolicy
+metadata:
+  name: chipcie-legacy
+  namespace: flux-system
+spec:
+  imageRepositoryRef:
+    name: chipcie-legacy
+  filterTags:
+    pattern: "^(?P<ts>.*)-[a-fA-F0-9]+"
+    extract: "$ts"
+  policy:
+    numerical:
+      order: asc

--- a/apps/chipcie-legacy/kustomization.yaml
+++ b/apps/chipcie-legacy/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - image.yaml
+  - release.yaml

--- a/apps/chipcie-legacy/release.yaml
+++ b/apps/chipcie-legacy/release.yaml
@@ -1,0 +1,40 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: chipcie-legacy
+  namespace: default
+spec:
+  interval: 15m
+  chart:
+    spec:
+      chart: ./archive
+      version: "0.1.x"
+      interval: 15m
+      reconcileStrategy: Revision
+      sourceRef:
+        kind: GitRepository
+        name: wisvch
+        namespace: flux-system
+  values:
+    nameOverride: chipcie-legacy
+    fullnameOverride: chipcie-legacy
+    tlsSecret: wisvch-tls
+    domains:
+      - 2001.bapc.eu
+      - 2002.nwerc.eu
+      - 2005.bapc.eu
+      - 2008.bapc.eu
+      - 2012.nwerc.eu
+      - 2013.nwerc.eu
+      - 2016.bapc.eu
+      - 2020.bapc.eu
+    replicaCount: 1
+    containerPort: 8080
+    service:
+      type: ClusterIP
+      port: 80
+    image:
+      repository: ghcr.io/wisvch/chipcie-legacy
+      tag: 20230305-91acaa0 # {"$imagepolicy": "flux-system:chipcie-legacy:tag"}
+      pullPolicy: IfNotPresent
+      pullSecrets: {}

--- a/apps/chipcie-nwerc-2022/image.yaml
+++ b/apps/chipcie-nwerc-2022/image.yaml
@@ -1,0 +1,23 @@
+apiVersion: image.toolkit.fluxcd.io/v1beta1
+kind: ImageRepository
+metadata:
+  name: chipcie-nwerc-2022
+  namespace: flux-system
+spec:
+  image: ghcr.io/wisvch/nwerc-2022
+  interval: 15m0s
+---
+apiVersion: image.toolkit.fluxcd.io/v1beta1
+kind: ImagePolicy
+metadata:
+  name: chipcie-nwerc-2022
+  namespace: flux-system
+spec:
+  imageRepositoryRef:
+    name: chipcie-nwerc-2022
+  filterTags:
+    pattern: "^(?P<ts>.*)-[a-fA-F0-9]+"
+    extract: "$ts"
+  policy:
+    numerical:
+      order: asc

--- a/apps/chipcie-nwerc-2022/kustomization.yaml
+++ b/apps/chipcie-nwerc-2022/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - image.yaml
+  - release.yaml

--- a/apps/chipcie-nwerc-2022/release.yaml
+++ b/apps/chipcie-nwerc-2022/release.yaml
@@ -1,0 +1,32 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: chipcie-nwerc-2022
+  namespace: default
+spec:
+  interval: 15m
+  chart:
+    spec:
+      chart: ./static-site
+      version: "0.1.x"
+      interval: 15m
+      reconcileStrategy: Revision
+      sourceRef:
+        kind: GitRepository
+        name: wisvch
+        namespace: flux-system
+  values:
+    nameOverride: chipcie-nwerc-2022
+    fullnameOverride: chipcie-nwerc-2022
+    tlsSecret: chipcie-contests-tls
+    domain: 2022.nwerc.eu
+    replicaCount: 1
+    containerPort: 8080
+    service:
+      type: ClusterIP
+      port: 80
+    image:
+      repository: ghcr.io/wisvch/nwerc-2022
+      tag: 20230327-7eb9df3 # {"$imagepolicy": "flux-system:chipcie-nwerc-2022:tag"}
+      pullPolicy: IfNotPresent
+      pullSecrets: {}

--- a/apps/chipcie-nwerc-2023/image.yaml
+++ b/apps/chipcie-nwerc-2023/image.yaml
@@ -1,0 +1,23 @@
+apiVersion: image.toolkit.fluxcd.io/v1beta1
+kind: ImageRepository
+metadata:
+  name: chipcie-nwerc-2023
+  namespace: flux-system
+spec:
+  image: ghcr.io/wisvch/chipcie-nwerc-2023
+  interval: 15m0s
+---
+apiVersion: image.toolkit.fluxcd.io/v1beta1
+kind: ImagePolicy
+metadata:
+  name: chipcie-nwerc-2023
+  namespace: flux-system
+spec:
+  imageRepositoryRef:
+    name: chipcie-nwerc-2023
+  filterTags:
+    pattern: "^(?P<ts>.*)-[a-fA-F0-9]+"
+    extract: "$ts"
+  policy:
+    numerical:
+      order: asc

--- a/apps/chipcie-nwerc-2023/kustomization.yaml
+++ b/apps/chipcie-nwerc-2023/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - image.yaml
+  - release.yaml
+  - redirect.yaml

--- a/apps/chipcie-nwerc-2023/redirect.yaml
+++ b/apps/chipcie-nwerc-2023/redirect.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    nginx.ingress.kubernetes.io/temporal-redirect: https://2023.nwerc.eu$request_uri
+  name: redirect-nwerc
+  namespace: default
+spec:
+  rules:
+    - host: nwerc.eu
+    - host: www.nwerc.eu
+  tls:
+    - hosts:
+        - nwerc.eu
+        - www.nwerc.eu
+      secretName: chipcie-contests-tls

--- a/apps/chipcie-nwerc-2023/release.yaml
+++ b/apps/chipcie-nwerc-2023/release.yaml
@@ -1,0 +1,32 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: chipcie-nwerc-2023
+  namespace: default
+spec:
+  interval: 15m
+  chart:
+    spec:
+      chart: ./static-site
+      version: "0.1.x"
+      interval: 15m
+      reconcileStrategy: Revision
+      sourceRef:
+        kind: GitRepository
+        name: wisvch
+        namespace: flux-system
+  values:
+    nameOverride: chipcie-nwerc-2023
+    fullnameOverride: chipcie-nwerc-2023
+    tlsSecret: chipcie-contests-tls
+    domain: 2023.nwerc.eu
+    replicaCount: 1
+    containerPort: 8080
+    service:
+      type: ClusterIP
+      port: 80
+    image:
+      repository: ghcr.io/wisvch/chipcie-nwerc-2023
+      tag: 20230323-8e3b1d1 # {"$imagepolicy": "flux-system:chipcie-nwerc-2023:tag"}
+      pullPolicy: IfNotPresent
+      pullSecrets: {}

--- a/infrastructure/certs/certificates/chipcie-contests.yaml
+++ b/infrastructure/certs/certificates/chipcie-contests.yaml
@@ -31,4 +31,4 @@ spec:
     - "2020.bapc.eu"
   issuerRef:
     kind: Issuer
-    name: transip
+    name: http01

--- a/infrastructure/certs/certificates/chipcie-contests.yaml
+++ b/infrastructure/certs/certificates/chipcie-contests.yaml
@@ -1,0 +1,25 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: chipcie-contests
+  namespace: default
+spec:
+  secretName: chipcie-contests-tls
+  duration: 2160h
+  renewBefore: 360h
+  isCA: false
+  privateKey:
+    algorithm: RSA
+    encoding: PKCS1
+    size: 4096
+  usages:
+    - server auth
+    - client auth
+  dnsNames:
+    # Following line should be removed once the current site for NWERC is no longer hosted on this cluster (should be 2024)
+    - "nwerc.eu"
+    - "*.nwerc.eu"
+    - "*.bapc.eu"
+  issuerRef:
+    kind: Issuer
+    name: transip

--- a/infrastructure/certs/certificates/chipcie-contests.yaml
+++ b/infrastructure/certs/certificates/chipcie-contests.yaml
@@ -16,10 +16,19 @@ spec:
     - server auth
     - client auth
   dnsNames:
-    # Following line should be removed once the current site for NWERC is no longer hosted on this cluster (should be 2024)
+    # Following two lines should be removed once the current site for NWERC is no longer hosted on this cluster (should be 2024)
     - "nwerc.eu"
-    - "*.nwerc.eu"
-    - "*.bapc.eu"
+    - "www.nwerc.eu"
+    - "2002.nwerc.eu"
+    - "2012.nwerc.eu"
+    - "2013.nwerc.eu"
+    - "2022.nwerc.eu"
+    - "2023.nwerc.eu"
+    - "2001.bapc.eu"
+    - "2005.bapc.eu"
+    - "2008.bapc.eu"
+    - "2016.bapc.eu"
+    - "2020.bapc.eu"
   issuerRef:
     kind: Issuer
     name: transip

--- a/infrastructure/certs/issuers.yaml
+++ b/infrastructure/certs/issuers.yaml
@@ -20,3 +20,19 @@ spec:
               privateKeySecretRef:
                 name: transip
                 key: privateKey
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: http01
+  namespace: default
+spec:
+  acme:
+    email: beheer@ch.tudelft.nl
+    server: https://acme-v02.api.letsencrypt.org/directory
+    privateKeySecretRef:
+      name: http01-issuer-key
+    solvers:
+      - http01:
+          ingress:
+            class: nginx


### PR DESCRIPTION
This contains all the BAPC and NWERC websites hosted on commissies.ch.tudelft.nl and the old cluster(BAPC 2020 and NWERC 2022). All sites before 2022 are archived and use the the `archive` chart (BAPC 2020 is added by WISVCH/chipcie-legacy#1). The NWERC 2022 and 2023 which still receive updates use the `static-site` chart. I have added an ingress redirect for the 2023 site based on what was used in 2022 in the old cluster. 

Please take a good look at the Certificate configuration, because I have no experience with cert-manager and the domains are not maintained by CH but by SURFnet.

@robertdijk can you take care of the DNS entries for

- 2001.bapc.eu
- 2002.nwerc.eu
- 2005.bapc.eu
- 2008.bapc.eu
- 2012.nwerc.eu
- 2013.nwerc.eu
- 2016.bapc.eu
- 2020.bapc.eu
- 2022.nwerc.eu
- 2023.nwerc.eu

I expect the best is to let them be set the `CNAME wisv.ch`, so future ip changes doesn't require manual updates. Unless @WISVCH/beheer has a different preference.