### PR TITLE
Gateway HTTP -> HTTPS

### DIFF
--- a/requirements/gateway/gateway.yaml
+++ b/requirements/gateway/gateway.yaml
@@ -1,14 +1,25 @@
+# https://cloud.google.com/kubernetes-engine/docs/how-to/deploying-gateways#redirect_http_traffic_from_the_gateway_namespace
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: gateway-infra
+---
 apiVersion: gateway.networking.k8s.io/v1beta1
 kind: Gateway
 metadata:
   name: gateway
-  namespace: default
+  namespace: gateway-infra
 spec:
   gatewayClassName: gke-l7-global-external-managed
   listeners:
   - name: https
     protocol: HTTPS
     port: 443
+    allowedRoutes:
+      kinds:
+      - kind: HTTPRoute
+      namespaces:
+        from: All
     tls:
       mode: Terminate
       options:
@@ -16,6 +27,11 @@ spec:
   - name: http
     protocol: HTTP
     port: 80
+    allowedRoutes:
+      kinds:
+      - kind: HTTPRoute
+      namespaces:
+        from: Same
   addresses:
   - type: NamedAddress
     value: gce-load-balancer-ipv4
@@ -31,3 +47,19 @@ spec:
   domains:
     - cod.wisv.ch
     - chipcie.wisv.ch
+---
+kind: HTTPRoute
+apiVersion: gateway.networking.k8s.io/v1beta1
+metadata:
+  name: redirect
+  namespace: gateway-infra
+spec:
+  parentRefs:
+  - namespace: gateway-infra
+    name: external-http
+    sectionName: http
+  rules:
+  - filters:
+    - type: RequestRedirect
+      requestRedirect:
+        scheme: https


### PR DESCRIPTION
I followed https://cloud.google.com/kubernetes-engine/docs/how-to/deploying-gateways#redirect_http_traffic_from_the_gateway_namespace to setup HTTP to HTTPS redirect. 

I placed the gateway in its own namespace.

I am not sure if this will break something. @praseodym @julian9499 what do you think?