### PR TITLE
Add the NWERC 2024 site to the cluster

### DIFF
--- a/apps/_clusters/release/kustomization.yaml
+++ b/apps/_clusters/release/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
   - ../../chipcie-legacy
   - ../../chipcie-nwerc-2022
   - ../../chipcie-nwerc-2023
+  - ../../chipcie-nwerc-2024
   - ../../chipcie-website
   - ../../choice
   - ../../cod

--- a/apps/chipcie-nwerc-2024/image.yaml
+++ b/apps/chipcie-nwerc-2024/image.yaml
@@ -1,0 +1,23 @@
+apiVersion: image.toolkit.fluxcd.io/v1beta1
+kind: ImageRepository
+metadata:
+  name: nwerc-2024
+  namespace: flux-system
+spec:
+  image: ghcr.io/wisvch/nwerc-2024
+  interval: 15m0s
+---
+apiVersion: image.toolkit.fluxcd.io/v1beta1
+kind: ImagePolicy
+metadata:
+  name: nwerc-2024
+  namespace: flux-system
+spec:
+  imageRepositoryRef:
+    name: nwerc-2024
+  filterTags:
+    pattern: "^(?P<ts>.*)-[a-fA-F0-9]+"
+    extract: "$ts"
+  policy:
+    numerical:
+      order: asc

--- a/apps/chipcie-nwerc-2024/kustomization.yaml
+++ b/apps/chipcie-nwerc-2024/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 resources:
   - image.yaml
   - release.yaml
+  - redirect.yaml

--- a/apps/chipcie-nwerc-2024/redirect.yaml
+++ b/apps/chipcie-nwerc-2024/redirect.yaml
@@ -15,7 +15,7 @@ spec:
     - filters:
         - type: URLRewrite
           urlRewrite:
-            hostname: 2023.nwerc.eu
+            hostname: 2024.nwerc.eu
       backendRefs:
-        - name: nwerc-2023
+        - name: nwerc-2024
           port: 80

--- a/apps/chipcie-nwerc-2024/release.yaml
+++ b/apps/chipcie-nwerc-2024/release.yaml
@@ -1,0 +1,32 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
+kind: HelmRelease
+metadata:
+  name: nwerc-2024
+  namespace: default
+spec:
+  interval: 15m
+  chart:
+    spec:
+      chart: ./static-site
+      version: "0.1.x"
+      interval: 15m
+      reconcileStrategy: Revision
+      sourceRef:
+        kind: GitRepository
+        name: wisvch
+        namespace: flux-system
+  values:
+    nameOverride: nwerc-2024
+    fullnameOverride: nwerc-2024
+    domains:
+      - 2024.nwerc.eu
+    replicaCount: 1
+    containerPort: 8080
+    service:
+      type: ClusterIP
+      port: 80
+    image:
+      repository: ghcr.io/wisvch/nwerc-2024
+      tag: 20240403-4feac02 # {"$imagepolicy": "flux-system:nwerc-2024:tag"}
+      pullPolicy: IfNotPresent
+      pullSecrets: {}


### PR DESCRIPTION
This is a copy paste from the nwerc-2023 with a ctrl-f on 2023. Also moves the redirect from 2023 to 2024.