### PR TITLE
Different postgres user per application

### DIFF
--- a/apps/choice/release.yaml
+++ b/apps/choice/release.yaml
@@ -38,10 +38,10 @@ spec:
       valuesKey: port
       targetPath: postgres.port
     - kind: Secret
-      name: postgres
-      valuesKey: username
+      name: choice
+      valuesKey: pg-username
       targetPath: postgres.username
     - kind: Secret
-      name: postgres
-      valuesKey: password
+      name: choice
+      valuesKey: pg-password
       targetPath: postgres.password

--- a/apps/dienst2/release.yaml
+++ b/apps/dienst2/release.yaml
@@ -31,12 +31,12 @@ spec:
       cloudSQL: true
   valuesFrom:
     - kind: Secret
-      name: postgres
-      valuesKey: username
+      name: dienst2
+      valuesKey: pg-username
       targetPath: postgres.username
     - kind: Secret
-      name: postgres
-      valuesKey: password
+      name: dienst2
+      valuesKey: pg-password
       targetPath: postgres.password
     - kind: Secret
       name: dienst2

--- a/apps/events/deploy.yaml
+++ b/apps/events/deploy.yaml
@@ -99,14 +99,14 @@ spec:
               value: null
               valueFrom:
                 secretKeyRef:
-                  name: postgres
-                  key: username
+                  name: events
+                  key: pg-username
             - name: SPRING_DATASOURCE_PASSWORD
               value: null
               valueFrom:
                 secretKeyRef:
-                  name: postgres
-                  key: password
+                  name: events
+                  key: pg-password
             - name: SPRING_DATASOURCE_URL
               value: jdbc:postgresql://127.0.0.1:5432/events
             - name: SPRING_JPA_HIBERNATE_HB2MDDL_AUTO

--- a/apps/listmonk/release.yaml
+++ b/apps/listmonk/release.yaml
@@ -26,12 +26,12 @@ spec:
       valuesKey: host
       targetPath: postgres.host
     - kind: Secret
-      name: postgres
-      valuesKey: username
+      name: listmonk
+      valuesKey: pg-username
       targetPath: postgres.user
     - kind: Secret
-      name: postgres
-      valuesKey: password
+      name: listmonk
+      valuesKey: pg-password
       targetPath: postgres.password
     - kind: Secret
       name: listmonk

--- a/apps/mand/release.yaml
+++ b/apps/mand/release.yaml
@@ -39,12 +39,12 @@ spec:
       valuesKey: port
       targetPath: postgres.port
     - kind: Secret
-      name: postgres
-      valuesKey: username
+      name: mand
+      valuesKey: pg-username
       targetPath: postgres.username
     - kind: Secret
-      name: postgres
-      valuesKey: password
+      name: mand
+      valuesKey: pg-password
       targetPath: postgres.password
     - kind: Secret
       name: mand

--- a/secrets/README.md
+++ b/secrets/README.md
@@ -1,13 +1,32 @@
 # Secrets
 
 This folder contains all the secrets that are used by deployments.
-These secrets can be changed by copying the `{name}.tpl.yaml`'s file content from the `templates` directory into the associated `{name}.yaml` file and filling in the secrets.
-One can then encrypt the file by using [mozilla sops](https://github.com/mozilla/sops) with the public key of the cluster: `age1ug2fepnvaqsfpn7t5gjjh2l0j8074jwh9h50pnjcjxn08v8pp3xq7ymxn2`.
+The secrets are encrypted using [mozilla sops](https://github.com/mozilla/sops) with the following public key of the cluster:
 
-The encryption method decrypts the file in place. The commando used to encrypt is:
+```
+age1ug2fepnvaqsfpn7t5gjjh2l0j8074jwh9h50pnjcjxn08v8pp3xq7ymxn2
+```
+
+## Creating a new secret
+
+To create a new secret:
+
+1. Create a template file without any secrets in the `templates` folder and name it `{name}.tpl.yaml`.
+2. Copy this file in the `secrets` directory (removing the `tpl` extension part) and fill in the secrets.
+3. Use `sops` to encrypt the secrets file.
 
 ```bash
-sops --age=age1ug2fepnvaqsfpn7t5gjjh2l0j8074jwh9h50pnjcjxn08v8pp3xq7ymxn2 --encrypt --encrypted-regex '^(data|stringData)$' --in-place .\{name}.yaml
+sops --age=age1ug2fepnvaqsfpn7t5gjjh2l0j8074jwh9h50pnjcjxn08v8pp3xq7ymxn2 --encrypt --encrypted-regex '^(data|stringData)$' --in-place {name}.yaml
 ```
 
 The cluster will automatically decrypt the secrets with its private key during runtime.
+
+## Editing existing secrets
+
+To edit an already encrypted file, set the private key in the `SOPS_AGE_KEY` environment variable, and use the `sops` command to edit the file:
+
+```bash
+sops {name}.yaml
+```
+
+When you exit the editor, the file will be encryped and saved, overwriting the previous file.

--- a/secrets/choice.yaml
+++ b/secrets/choice.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: choice
+    namespace: default
+stringData:
+    pg-username: ENC[AES256_GCM,data:kek50ZC3,iv:r7VPWD9z+67UjjBG6gRo6ZjChV9A7pwpNDG70xIQEDE=,tag:XzVmmYz5/YE3nJXOiJH7IQ==,type:str]
+    pg-password: ENC[AES256_GCM,data:bjo/j3zJmnQ+6jWf80hd/yfD97o=,iv:rq8ky09ZmtfYnGrKaD4ceZZUqcrng98wAilNiToGZHQ=,tag:R5Dz+MQleumCqrwfmv9YTw==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age:
+        - recipient: age1ug2fepnvaqsfpn7t5gjjh2l0j8074jwh9h50pnjcjxn08v8pp3xq7ymxn2
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBLNXlzNXRzNDlTaVhxdGwy
+            R2Y2Sk9pNlZaMm9xU2lSN0ROd1B4YUdZUG13ClBQcndydmEvcUs4RWhKRG9zVkw4
+            aG9zaTdTK1BKeitDd2d6VkVoUHBEOHcKLS0tIGIvQWQ3L3hYMHU4UCtBZzZEMUV5
+            bVVNRlN4SmNUVXFZeUcvdE9VanpkS2sKLivuSKpur34AeKgBjzdaOEtdcoqEzejw
+            TYjH66Txmid4/HUKW1BQf3Dh+ZpUtFthK/jXNakXZJiWzdh7P1usBA==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2024-05-27T20:50:14Z"
+    mac: ENC[AES256_GCM,data:aidKoc7TKMtKTJSuOQ9vzPxHuu4Hl/+fBGoxmHNwiKoefjvEzipksmw1Iu2qDE5/4SrA74cVtL9iJZzTeBkE38dqaxihdj4bdx4DNeyznmp7lj0MQBHPXw6/MwNF+DMKyRtP8vT/s1Vj+m929wLPSJpTwiu7GD1XSeZjYgZddm4=,iv:qxmyqeJjpge1ze0XkFnAj6mJm3JhfhU7Rf70siP35/o=,tag:mdkNpF67Pu2JqZBWVODniQ==,type:str]
+    pgp: []
+    encrypted_regex: ^(data|stringData)$
+    version: 3.8.1

--- a/secrets/dienst2.yaml
+++ b/secrets/dienst2.yaml
@@ -6,6 +6,8 @@ metadata:
 stringData:
     secret_key: ENC[AES256_GCM,data:8EMBhOG2Pmx9ndnWyaJoAeDPp6ojffBiG9bO6YPHIk7vEnVV4C1pAjp/9CY2faILfuI=,iv:CTFUn+seCYUT/aoCAeV4SdgWEtfVqvqCQ+3S8S8vkB0=,tag:xVWrD3YP4aod4VFM1PqI5g==,type:str]
     iap_expected_audience: ENC[AES256_GCM,data:iiJVuOAJ+swrrvKd5fsVXyR7RqKs+T/yo8sPVMtuasGW67kRtUCZq2hJ6Auq4tN89V6sULqvBruYN8o7P8Qu4QQ=,iv:KnzFreYZd9oUaTS9kQ1pRrm4lx9iMVqv7khs2xzSbn0=,tag:ApRMu2jyWhsLE8+84utAxA==,type:str]
+    pg-username: ENC[AES256_GCM,data:qrPiNl8yRA==,iv:XaHo7B1vjCVRcoC8w7fYlspDEY3X9eawAAtoHEgQyGY=,tag:GHIep9WgZzVDlSWKO1nDXQ==,type:str]
+    pg-password: ENC[AES256_GCM,data:tZTrz6nJ/A+0lGU+24kSkc/h5gQ=,iv:pWJqbt1ULq5kZN5ajaacGs2OgVDXr2+idt01+CJ51UM=,tag:isjZ9cGEmdsWG17xwJFEDA==,type:str]
 sops:
     kms: []
     gcp_kms: []
@@ -21,8 +23,8 @@ sops:
             NG9IOEVXWnl0VUFuY2J2VFlUdjdEZkkKXYLXsELYo7hNFnrbIx3T+iOyOKxG1gCa
             nW/3S8FBCxUdDTzewZffeux8Jm1Ao46eNzxZNytE2CAnJhYmLpGZbA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2023-08-18T11:53:00Z"
-    mac: ENC[AES256_GCM,data:iMfsoK+xYWR5SDrF1gC8qa4uNiFtBnCYF09sVSO4t4yH2nCyY78YzbHVPimKyTcqHJNXgh8WboAqKlNdcVI1SUR3aFUxYcnzRQLvLDPJIodl2byKvqG8pGsUIbWn48DMrEzetYcvI28Keg0Kzspvrcu9FBUL2BR2gGzpcrrWAd0=,iv:KJ7bVdeBGWM0UTMfYxb4QpCVerFGCi0AiiiokaHeKWs=,tag:A1XNGM/yf+flNJWNdTpPNA==,type:str]
+    lastmodified: "2024-05-27T20:44:06Z"
+    mac: ENC[AES256_GCM,data:S5TnYGG79qrd8eH0oENIdQRoqZMVXUI/0rQD1cFOpPDxYKI2/SDYlbQY+71C51wG1QXEQLzeIifEce5QbdgVDSvCJ3kCGiNhWFpGt6zCpp+SRYHE3O6aMm60T6HmMsFvJtXGRraDq3wv3ga84EAROAv64PNcGuL6aMqm4AH5/6I=,iv:F1uVmSHDnN2pZ8MRPnOEPrlADlfprTB+7ruGCBqmiIM=,tag:JyJZ5nJ5bvtFAoJJ2e8whQ==,type:str]
     pgp: []
     encrypted_regex: ^(data|stringData)$
-    version: 3.7.3
+    version: 3.8.1

--- a/secrets/events.yaml
+++ b/secrets/events.yaml
@@ -7,6 +7,8 @@ stringData:
     mollie-key: ENC[AES256_GCM,data:9Gh8WJDOAnd5snrmy4PWuUvZ0Aj7icDa2imgKOvMeUulRKs=,iv:65nCJjjkqr+ETn6n+PKoAjadDs7xgRfwVmS8b4/GVJs=,tag:PvffCZSguBs9a6ecqZDN2A==,type:str]
     connect-client-secret: ENC[AES256_GCM,data:5HZkXke8SrjyshRqUoUOQ79j08q0gCl6ZTowcLtosjuIV7asTTBUblgDDzQZTG0PwohGC1gL+qCAMPxAbyAnU1kyoVCdkfy9TCy52PoHEN8bfWQGvWI=,iv:1/uHslLNEh0Y2i/1y0fgMYpxtN+/70Gsj0FqU4RqyVg=,tag:72X8Tb2pj8NVg9ZkoRq9uA==,type:str]
     connect-client-id: ENC[AES256_GCM,data:jdBGd+SgTbVI5AIMZFsbdUZVBjsI5WGgIm4jnAlTekVMrtJG,iv:qpFXNlAe5+MW9DmxGQq2Jj2iY7FR+Jso4jwRgMnO3WM=,tag:vmJFrZfAD45klD6JJXUkyg==,type:str]
+    pg-username: ENC[AES256_GCM,data:wKqrRayE,iv:2szQ/1llfAeWXQzWGqClyHrYqvalcl1eh4364ZPIo08=,tag:DPzDqetn6jw61Ua3JjR4ww==,type:str]
+    pg-password: ENC[AES256_GCM,data:SgUOfcNeRhwuQ3JSL4278QVOIw8=,iv:/jWLcZbMaOwU5EOw1MZFER3cAIj+E1VpW6HoODcULw8=,tag:zmm/TwgNDGIdGEJiVmECTw==,type:str]
 sops:
     kms: []
     gcp_kms: []
@@ -22,8 +24,8 @@ sops:
             OVEyS2ZPWnpjbjBZUTVJbXMrRHFBWVEKeYBk6tdzeM1zn59z6weunuYkzQkr4TzO
             XWcjQGAL6IXrEjqscSeYe15Zblc1WOYlITFXkbZmSIGQjAxVi3mv1A==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2023-11-02T18:21:12Z"
-    mac: ENC[AES256_GCM,data:pM5J/HndzEvalSNSujR5PEzCsQ8rxNiT57SO10NT5QP84sVeSaqA6vsLzvwq4mV4vHEwLFPRgomTEYqqZBj2v+v8fueGYOCp0MHUg8CQtA/G4DoOXJSRObcftOWZVAi/4X1++052efuOT4i39edL61t8/gkgkmCG/yRyehQcgHo=,iv:f71qNqN39JK1T9bbZSHmToLZXqI/2X5AAjC5LFauBVQ=,tag:xaG2PbKQIhhUypnYKS871g==,type:str]
+    lastmodified: "2024-05-27T20:32:21Z"
+    mac: ENC[AES256_GCM,data:C7aWSvgX9tVcBIo77cBbUeGKst88D22UMFbVZ1Syl9Cs9FXwq4/cNcZ2lWSwYXD5JKuS3qMMGqNEkUnQf6JPoZVPybvgtfJ0I3WzaDxmmJ9FB97J9gjjMxu+I1F1zoL7guO/DZ4bkIafbxC7BpgBXCZsAms+ZN6k1boDgYPlAkQ=,iv:ey15+WSLw8VWOJdlf5Ogy0XVqL3uNJgFa4mA/eHMSD8=,tag:IgbyTlur22gSH8v75YIbVg==,type:str]
     pgp: []
     encrypted_regex: ^(data|stringData)$
-    version: 3.7.3
+    version: 3.8.1

--- a/secrets/listmonk.yaml
+++ b/secrets/listmonk.yaml
@@ -4,10 +4,10 @@ metadata:
     name: listmonk
     namespace: default
 stringData:
-    postgresUser: ENC[AES256_GCM,data:DWHvoC39PUs=,iv:aC4SL2ivQmpvqFFUosvPZp9s2f6k5vhdiPraplXpvVs=,tag:1gJgNLZJHlYhYAMd1IVf0A==,type:str]
-    postgresPassword: ENC[AES256_GCM,data:QQJE+3blyWHq7Nw5xwdEMqyCofdi2+E0N+0jgKYRYug=,iv:hKE5SLZvYrAaD+HwhrikUwS9Nrva2Gvh/TABqT5NRME=,tag:n9IHlgzbx2vTBZWTEoaNaw==,type:str]
     adminUser: ENC[AES256_GCM,data:LFrKoDqr,iv:3lJFzYfMVY4nuV1BXRTs6vFJQAAH4Hrkdq8hE22p0tM=,tag:NL4FYD86CB1AhCrkETWeHA==,type:str]
     adminPassword: ENC[AES256_GCM,data:IQ2CC3SkuS16elA3PtWgw7FUTEe3aoZ8QvaYHNkJJp+0MZ6AE4yVHRxFyMpDA07DQwpMc4Otb7ggej6LfJZlHVGh7lzxDYozuqLwHlDEEelBGlvidJ5/iORabCQMFNxG/3o+JA==,iv:dXTNnGG0k+ZcBH/Fx0Ag9PXznzWRSRJ6RrqKZkfm5gs=,tag:seR1h4v9ZZJslH/rDPI2jw==,type:str]
+    pg-username: ENC[AES256_GCM,data:BHLkOdrgSmE=,iv:6iuk9McpgXvNW0KAr6WvuHfcRXGpS6ktpBJgkSVDlck=,tag:nbRGmVkdnkr7ZUHCF6Gxvw==,type:str]
+    pg-password: ENC[AES256_GCM,data:CipS7wUoqmS7axt5NpLJ1lBJmvw=,iv:im+lK7zj9mKNOmdwXvn89Sa85ngPe8nz4MFtQ4zvKhg=,tag:Z1t9t+De1MOUDikr2Aqzsg==,type:str]
 sops:
     kms: []
     gcp_kms: []
@@ -23,8 +23,8 @@ sops:
             YmVhYTlIYncrZUU2bHliQVR6SzA2SUkKzZCeQHxBUVtH63DqtfFwRSa2BmTNRlPS
             Cv9dBDUN3lwa9GgYXJzreZwY/BRQDU4ia3mm1V0UBt4vr6jLj6FR6g==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2023-04-03T14:28:00Z"
-    mac: ENC[AES256_GCM,data:QdiyYSfSlJpUOPAy1SU7yVyVkSVnryKb4S3WuHlVhCWkUwx831UoPDWVqGtfLW4cvI4Wl/bPFugFctc+oZAy8A4SGK7s/5AUsr9r0ARua4sPl3cl0Kq9lBshwyI3Dx9IdKT4rTEHwnVaLRExRN5/sc2NTIcqAIRcjN9JnNfc+EM=,iv:eUtDYgn58oglt5oF0xIZb8LKh3xOiygQQT07CjKQNlA=,tag:RlCo8YY4yUlRcSy1Bi0TVw==,type:str]
+    lastmodified: "2024-05-27T20:58:10Z"
+    mac: ENC[AES256_GCM,data:/53lWmNW8BIAYkOvE+Lhpjy3mTmGuSgTbts9NfHJ2wx2X7Dj8tAqS5wqdsR9PVVRBmo0Z5sKdXW6BE6DmxxIoCJqmvzpJJoQ/u9lzHbux13D6MhpzCKjBLbIhSnSb60Q6Oxut17WLV2ccmCY+RRiOCuyQM//8a86Je0u/bPrZiA=,iv:eSFX6Arvo5WltblWcw5z4hijKhyE3XIKTLgO9cBxZTM=,tag:WrmgjHbcFiZJhIGuaKBTIw==,type:str]
     pgp: []
     encrypted_regex: ^(data|stringData)$
-    version: 3.7.3
+    version: 3.8.1

--- a/secrets/mand.yaml
+++ b/secrets/mand.yaml
@@ -1,27 +1,29 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: mand
-  namespace: default
+    name: mand
+    namespace: default
 data:
-  clientSecret: ENC[AES256_GCM,data:NtxRIWP7ZenRDTyteS5JDJ57ZBRD8BBnSr1FJZVhLAEUpCYFxk/9oGTl0AQ9bKzxuztU1ZjqHUetgJsjEirsCWikBVRZy830N6xxLIxDHKmnPDd5nd9XzAncgtFhtHwgJ/lJSCifnkkF0gu2zXmSetHUAAc=,iv:6JVFwGa8q1VZs0f8rgASt0UF9X9ZuP/gbNWwA9+2mxE=,tag:rn7BNPb/fD6E+Tdbu6HpZw==,type:str]
+    clientSecret: ENC[AES256_GCM,data:NtxRIWP7ZenRDTyteS5JDJ57ZBRD8BBnSr1FJZVhLAEUpCYFxk/9oGTl0AQ9bKzxuztU1ZjqHUetgJsjEirsCWikBVRZy830N6xxLIxDHKmnPDd5nd9XzAncgtFhtHwgJ/lJSCifnkkF0gu2zXmSetHUAAc=,iv:6JVFwGa8q1VZs0f8rgASt0UF9X9ZuP/gbNWwA9+2mxE=,tag:rn7BNPb/fD6E+Tdbu6HpZw==,type:str]
+    pg-username: ENC[AES256_GCM,data:iXrVVQ==,iv:4GMBL80k+z6GgJTMRQl0mnmEpJ5Vmni19MgQnCBVEvU=,tag:H2vHKAw+tMBWHTQwlYOhpA==,type:str]
+    pg-password: ENC[AES256_GCM,data:zURPD5MbxBAP+momDxJnBeOOozk=,iv:ERj4htkegbAdZG+SraZjkwNEYE+qc29rN0zk2+g39wM=,tag:ot4CUQNfRBCzxi2u1Cos+g==,type:str]
 sops:
-  kms: []
-  gcp_kms: []
-  azure_kv: []
-  hc_vault: []
-  age:
-    - recipient: age1ug2fepnvaqsfpn7t5gjjh2l0j8074jwh9h50pnjcjxn08v8pp3xq7ymxn2
-      enc: |
-        -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBDZHhWOFYySmVJRE1ZU2VJ
-        VkpVV3FyTDF1bVB6dExBaXZpYVpMdHk0dkFvCnRod3RXbm1JTjdqYTBCMklBenRq
-        RGNtQzYwK21EV2M1UUhPMTB0RklVNlEKLS0tIE02YUhFTkN0Qk5QY0x2SUQ4cy9B
-        NjQxNzdqVURCTGRtdU5SUng0Wis5RUkKx5L84d0Gdy1J1ehFx/IWK3XkCmB1amr7
-        ih3Ffn4fYG4DxTkN8kIm4Aaw2zHqM1lkIsK3etbNUFfPoiu/uxhSqA==
-        -----END AGE ENCRYPTED FILE-----
-  lastmodified: "2022-12-21T00:59:19Z"
-  mac: ENC[AES256_GCM,data:4o9EvdJ+8ZmQ1H9X42gK28i4LT4yYyKIqyxUKOiCK9mFvNLGW8p+quXdRJZGEvMcN0j1P31N849nRBtzbUdgIuVOrOXKQrvsEUPmNcX4lKGEl6N+Nji7lcE8vJpZi3ZqU7DF5gZWyh29aJ+kFkBf0bSSKVGaNpvy0L8D3yOodUM=,iv:aUl/Mgt8hmJEMGDaMZZBjPDMRE/3jdy4Vla+IHVqL+Y=,tag:Y87cvbizJHNKK3ZcdpAx+g==,type:str]
-  pgp: []
-  encrypted_regex: ^(data|stringData)$
-  version: 3.7.3
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age:
+        - recipient: age1ug2fepnvaqsfpn7t5gjjh2l0j8074jwh9h50pnjcjxn08v8pp3xq7ymxn2
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBDZHhWOFYySmVJRE1ZU2VJ
+            VkpVV3FyTDF1bVB6dExBaXZpYVpMdHk0dkFvCnRod3RXbm1JTjdqYTBCMklBenRq
+            RGNtQzYwK21EV2M1UUhPMTB0RklVNlEKLS0tIE02YUhFTkN0Qk5QY0x2SUQ4cy9B
+            NjQxNzdqVURCTGRtdU5SUng0Wis5RUkKx5L84d0Gdy1J1ehFx/IWK3XkCmB1amr7
+            ih3Ffn4fYG4DxTkN8kIm4Aaw2zHqM1lkIsK3etbNUFfPoiu/uxhSqA==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2024-05-27T21:01:06Z"
+    mac: ENC[AES256_GCM,data:loTe59zSQBGmdam8AEzF3LDPL9xQh0rcEARMHfgN7y5s0LBhI/c2Y7ClP9sLK4tY1JVTYLBNVzelZ5LNooJhFCHgWbfuNhs7IzfhnGDWqP6101TmI5fnOzItyfmirovtpvmvfLoNclg2L8Pj1FIALPxw4ZyIYTiQZngW3b/JISg=,iv:/evURBPf2AUnZpcmLQ7nxj30pa/Gu+pXthxZ5T5ogGo=,tag:/3apXWRR97Lvwqvf7vyPQg==,type:str]
+    pgp: []
+    encrypted_regex: ^(data|stringData)$
+    version: 3.8.1

--- a/secrets/templates/choice.tpl.yaml
+++ b/secrets/templates/choice.tpl.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: choice
+  namespace: default
+stringData:
+  pg-username: ""
+  pg-password: ""

--- a/secrets/templates/dienst2.tpl.yaml
+++ b/secrets/templates/dienst2.tpl.yaml
@@ -6,3 +6,5 @@ metadata:
 stringData:
   secret_key: ""
   iap_expected_audience: ""
+  pg-username: ""
+  pg-password: ""

--- a/secrets/templates/events.tpl.yaml
+++ b/secrets/templates/events.tpl.yaml
@@ -7,3 +7,5 @@ stringData:
   mollie-key: ""
   connect-client-secret: ""
   connect-client-id: ""
+  pg-username: ""
+  pg-password: ""

--- a/secrets/templates/listmonk.tpl.yaml
+++ b/secrets/templates/listmonk.tpl.yaml
@@ -4,5 +4,7 @@ metadata:
   name: listmonk
   namespace: default
 stringData:
-  postgresUser: ""
-  postgresPassword: ""
+  adminUser: ''
+  adminPassword: ''
+  pg-username: ''
+  pg-password: ''

--- a/secrets/templates/mand.tpl.yaml
+++ b/secrets/templates/mand.tpl.yaml
@@ -5,3 +5,5 @@ metadata:
   namespace: default
 data:
   clientSecret: ""
+  pg-username: ""
+  pg-password: ""


### PR DESCRIPTION
For security purposes, different applications should use different users in our Google Cloud postgres instance. The users should have the minimal required privileges within their database.

**Before merging this PR, it should be verified that the users in the google cloud postgres instance have the correct permissions!**

Tasks:

- [ ] Create new users in Google Cloud postgres instance
  - [x] events
  - [x] dienst2
  - [x] choice
  - [x] listmonk
  - [x] mand
  - [ ] areafiftylan
  - [ ] areafiftylan-legacy
- [x] Update credentials in the application's secret file
- [ ]  Update (reduce) permissions of the new user in the postgres instance
- [ ] Merge and pray everything works? :)