### PR TITLE
Aoch adventofcode leaderboard

### DIFF
--- a/apps/_clusters/release/kustomization.yaml
+++ b/apps/_clusters/release/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../annugame
+  - ../../aoch
   - ../../archive
   # - ../../areafiftylan
   # - ../../areafiftylan-legacy

--- a/apps/aoch/deploy.yaml
+++ b/apps/aoch/deploy.yaml
@@ -1,0 +1,62 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: aoch
+  namespace: default
+  labels:
+    app: aoch
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: aoch
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  template:
+    metadata:
+      name: aoch
+      labels:
+        app: aoch
+    spec:
+      containers:
+        - name: aoch
+          image: ghcr.io/wisvch/aoch:20241127-fab2798 # {"$imagepolicy": "flux-system:adventofcode"}
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 20
+            successThreshold: 1
+            timeoutSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 20
+            successThreshold: 1
+            timeoutSeconds: 5
+          env:
+            - name: session
+              value: null
+              valueFrom:
+                secretKeyRef:
+                  name: aoch
+                  key: session
+            - name: leaderboard_id
+              value: 954860
+          resources:
+            limits:
+              memory: 512Mi
+            requests:
+              cpu: 50m
+              memory: 150Mi

--- a/apps/aoch/deploy.yaml
+++ b/apps/aoch/deploy.yaml
@@ -53,7 +53,7 @@ spec:
                   name: aoch
                   key: session
             - name: leaderboard_id
-              value: 954860
+              value: "954860"
           resources:
             limits:
               memory: 512Mi

--- a/apps/aoch/healthcheck.yaml
+++ b/apps/aoch/healthcheck.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: networking.gke.io/v1
+kind: HealthCheckPolicy
+metadata:
+  namespace: default
+  name: aoch
+spec:
+  default:
+    config:
+      type: HTTP
+      httpHealthCheck:
+        port: 8080
+        requestPath: /
+    logConfig:
+      enabled: true
+  targetRef:
+    group: ""
+    kind: Service
+    name: aoch

--- a/apps/aoch/httproute.yaml
+++ b/apps/aoch/httproute.yaml
@@ -1,0 +1,16 @@
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: HTTPRoute
+metadata:
+  name: aoch
+  namespace: default
+spec:
+  parentRefs:
+  - kind: Gateway
+    namespace: gateway-infra
+    name: gateway
+  hostnames:
+  - aoch.wisv.ch
+  rules:
+  - backendRefs:
+    - name: aoch
+      port: 80

--- a/apps/aoch/image.yaml
+++ b/apps/aoch/image.yaml
@@ -1,0 +1,23 @@
+apiVersion: image.toolkit.fluxcd.io/v1beta1
+kind: ImageRepository
+metadata:
+  name: aoch
+  namespace: flux-system
+spec:
+  image: ghcr.io/wisvch/aoch
+  interval: 15m0s
+---
+apiVersion: image.toolkit.fluxcd.io/v1beta1
+kind: ImagePolicy
+metadata:
+  name: aoch
+  namespace: flux-system
+spec:
+  imageRepositoryRef:
+    name: aoch
+  filterTags:
+    pattern: "^(?P<ts>.*)-[a-fA-F0-9]+"
+    extract: "$ts"
+  policy:
+    numerical:
+      order: asc

--- a/apps/aoch/kustomization.yaml
+++ b/apps/aoch/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - image.yaml
+  - deploy.yaml
+  - httproute.yaml
+  - service.yaml
+  - healthcheck.yaml

--- a/apps/aoch/service.yaml
+++ b/apps/aoch/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: aoch
+  name: aoch
+  namespace: default
+spec:
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app: aoch
+  sessionAffinity: None
+  type: ClusterIP

--- a/secrets/aoch.yaml
+++ b/secrets/aoch.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: aoch
+    namespace: default
+stringData:
+    session: ENC[AES256_GCM,data:EW49KqkGZhVpqq5zvoqw3PZSTxsE6RbifI+2AZZq3O8TtuZOpXw/1x4slKf6SnN/Q4L74TbqtDvlWWYomB8Yu5mFseg/NM2timuD+zCq7s0q4PvLB1/ABvcAgb6kL5h+AvUi9zJABh7MLliY/x66CnFXjMGF5TxwC+Twnua+sXs=,iv:L6cGTJoLaOxImDQ1WFPmuCs8OMvUbfuY1WXZX7O97vo=,tag:kBQ+hMkdv3XrPm2LofszhQ==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age:
+        - recipient: age1ug2fepnvaqsfpn7t5gjjh2l0j8074jwh9h50pnjcjxn08v8pp3xq7ymxn2
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBqbFQ4T3QyVldkNjVJZ2ZQ
+            SkhIQ0poTlM5UFVkeFBuUVUySzFPSUdZYXg4Cjc4RUV6MEpWbW1jSmd4L2NhS21E
+            WjlZcys1aUNEU2sxVVZwMnRRaTFwL0EKLS0tIE5DbWxKWE9Rc0I4T3RSbnB1elJk
+            MUZiRndoN1VxYjlFcVc4NkRNdUh2L2MKCfqqfLOfh+vB1gapixFzz4/ZxidTwn8F
+            C25Z7UDWcIJvoAM/g7RAy8uL0iUgTsQMw4inEwokaolkkOzicy1PiQ==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2024-11-27T13:42:09Z"
+    mac: ENC[AES256_GCM,data:0LAWFAlYyVd3lQQtI80+VGQNymwPIO2urliic8hLSsvYl9ZCvIPUgPSGVQXSjXfVl41oxhU4XeasR9iGW3DwJ2/W3Bn7UTh3ek+sG7U6O4dmymuL44cK9F508cxF1IvK2If96jKz2ht7ttXQ11CYf82msOdL/KVp1hafRF3aTS0=,iv:FFE7JNDWF54MxWHKaWM+g3G95KpgPa05LOKunUWEMi8=,tag:0mlRoM2QX6zr+ajDjbyWxg==,type:str]
+    pgp: []
+    encrypted_regex: ^(data|stringData)$
+    version: 3.9.1

--- a/secrets/templates/aoch.tpl.yaml
+++ b/secrets/templates/aoch.tpl.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: aoch
+  namespace: default
+stringData:
+  session: ""


### PR DESCRIPTION
Publish the advent of code CH leaderboard to `aoch.wisv.ch/` with the following paths:
- `/`
- `/challenge`
- `/leaderboard`
- `/leaderboard/today`

deployment should contain the env variables `session` and `leaderboard_id` of which `session` is gotten from the secrets (it is my own session cookie, which is required to be able to talk with the api).

I believe this should be configured correctly, however it is my first full deployment to the cluster (only made modifications before this) so I would appreciate it if someone looked at it and approved it :)