### PR TITLE
Disable non-relative applications

### DIFF
--- a/apps/_clusters/release/kustomization.yaml
+++ b/apps/_clusters/release/kustomization.yaml
@@ -1,9 +1,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ../../annugame
-  - ../../aocbot
-  - ../../aoch
+  # - ../../annugame
+  # - ../../aocbot
+  # - ../../aoch
   - ../../archive
   # - ../../areafiftylan
   # - ../../areafiftylan-legacy


### PR DESCRIPTION
Both advent of code and annugame have no relevance currently. Advent of code has passed and annugame is also not yet relevant.

To note, annugame should've already been disabled by Joshua.