### PR TITLE
Dienst2 network policy

### DIFF
--- a/apps/dienst2/release.yaml
+++ b/apps/dienst2/release.yaml
@@ -93,6 +93,37 @@ spec:
     run: dienst2
   type: ClusterIP
 ---
+# POD-level network policy to protect the service from internal traffic.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: dienst2-allow-internal-labels
+  namespace: default
+spec:
+  podSelector:
+    matchLabels:
+      run: dienst2
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector:
+        matchLabels:
+          access-dienst2: "true" # Allow access from e.g. website by adding access-dienst2 to the labels.
+    ports:
+    - protocol: TCP
+      port: 8000
+  
+  - from:
+    # Allow all traffic that comes through the load balancer. External access is gated by IAP see GCPBackendPolicy.
+    - ipBlock:
+        cidr: 35.191.0.0/16
+    - ipBlock:
+        cidr: 130.211.0.0/22
+    ports:
+    - protocol: TCP
+      port: 8000
+---
 apiVersion: networking.gke.io/v1
 kind: HealthCheckPolicy
 metadata:

--- a/apps/keycloak/deploy.yaml
+++ b/apps/keycloak/deploy.yaml
@@ -21,6 +21,7 @@ spec:
     metadata:
       labels:
         app: keycloak
+        access-dienst2: "true"
     spec:
       serviceAccountName: keycloak
       containers:

--- a/apps/website/deploy.yaml
+++ b/apps/website/deploy.yaml
@@ -21,6 +21,7 @@ spec:
       name: website
       labels:
         app: website
+        access-dienst2: "true"
     spec:
       serviceAccountName: website
       containers:


### PR DESCRIPTION
Prevent internal access to dienst2 of applications on the cluster.
Add "access-dienst2" to the labels to explicitly allow access for e.g. website.
All traffic through the gateway (and therefore IAP) is allowed by default. 
This PR does not add more exposure. It adds additional rules on POD-level.